### PR TITLE
v3.0.1 hotfix

### DIFF
--- a/besser/agent/core/session.py
+++ b/besser/agent/core/session.py
@@ -109,7 +109,8 @@ class Session:
         """Schedule the next call to manage_transition as soon as possible (cancelling the previously scheduled
         call).
         """
-        self._timer_handle.cancel()  # Cancel previously scheduled call to session.manage_transition()
+        if self._timer_handle:
+            self._timer_handle.cancel()  # Cancel previously scheduled call to session.manage_transition()
         self._event_loop.call_soon_threadsafe(self.manage_transition)
 
     def manage_transition(self) -> None:

--- a/besser/agent/core/state.py
+++ b/besser/agent/core/state.py
@@ -293,6 +293,7 @@ class State:
         Args:
             session (Session): the current session
         """
+        last_event = session.event
         run_fallback = False
         for i, next_transition in enumerate(self.transitions):
             if next_transition.is_event():
@@ -331,7 +332,7 @@ class State:
                 logger.error(f"An error occurred while executing '{self._fallback_body.__name__}' of state"
                             f"'{self._name}' in agent '{self._agent.name}'. See the attached exception:")
                 traceback.print_exc()
-        session.event = None
+        session.event = last_event
 
     def run(self, session: Session) -> None:
         """Run the state body.
@@ -347,4 +348,4 @@ class State:
                          f"{self._agent.name}'. See the attached exception:")
             traceback.print_exc()
         # Reset current event
-        session.event = None
+        # session.event = None  # If we remove the event, if there is an automatic or condition-based transition, we lose the event

--- a/besser/agent/platforms/websocket/streamlit_ui/chat.py
+++ b/besser/agent/platforms/websocket/streamlit_ui/chat.py
@@ -84,7 +84,7 @@ def write_message(message: Message, key_count: int, stream: bool = False):
                         st.write(f'- **Content:** {doc["content"]}')
 
         elif message.type in [MessageType.STR, MessageType.MARKDOWN]:
-            write_or_stream(message.content, stream=isinstance(message.content, str))
+            write_or_stream(message.content, stream=(stream and isinstance(message.content, str)))
 
 
 def load_chat():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = besser-agentic-framework
-version = 3.0.0
+version = 3.0.1
 author = Luxembourg Institute of Science and Technology
 description = BESSER Agentic Framework (BAF)
 long_description = file: README.md


### PR DESCRIPTION
- Session._timer_handle can be null if transition from initial state happens on the 1st transitions evaluation (fixed)
- Fixed streamlit UI chat bug
- Don't remove the session event after finishing state execution (if there is an automatic or condition-based transition, we lose the event)