### PR TITLE
Docs: Clarify filename in 'Your first agent' tutorial

### DIFF
--- a/docs/source/your_first_agent.rst
+++ b/docs/source/your_first_agent.rst
@@ -18,6 +18,8 @@ simple *How are you?* question. This workflow is repeated *ad infinitum*.
 
 You can also see the full agent code :doc:`here <examples/greetings_agent>`
 
+The following code should be saved in a Python file named `greetings_agent.py`.
+
 Import the dependencies
 -----------------------
 


### PR DESCRIPTION
Added a sentence to inform the reader that the code in the 'Your first agent' tutorial should be saved in a file named `greetings_agent.py`. This addresses issue #106.